### PR TITLE
Fix incorrect Ant 1.8.4 download URL

### DIFF
--- a/openjdk7/linux/build.sh
+++ b/openjdk7/linux/build.sh
@@ -38,7 +38,7 @@ function ensure_ant()
   if [ ! -d $OBF_DROP_DIR/ant ]; then
     mkdir -p $OBF_DROP_DIR/ant
     pushd $OBF_DROP_DIR/ant
-    curl -L http://mirrors.ircam.fr/pub/apache/ant/binaries/apache-ant-1.8.4-bin.tar.gz -o apache-ant-1.8.4-bin.tar.gz
+    curl -L http://archive.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.tar.gz -o apache-ant-1.8.4-bin.tar.gz
     tar xzf apache-ant-1.8.4-bin.tar.gz
     mv apache-ant-1.8.4/* .
     rmdir apache-ant-1.8.4

--- a/openjdk8-jigsaw/linux/build.sh
+++ b/openjdk8-jigsaw/linux/build.sh
@@ -40,7 +40,7 @@ function ensure_ant()
   if [ ! -x $OBF_DROP_DIR/ant/bin/ant ]; then
     mkdir -p $OBF_DROP_DIR/ant
     pushd $OBF_DROP_DIR/ant
-    curl -L http://mirrors.ircam.fr/pub/apache/ant/binaries/apache-ant-1.8.4-bin.tar.gz -o apache-ant-1.8.4-bin.tar.gz
+    curl -L http://archive.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.tar.gz -o apache-ant-1.8.4-bin.tar.gz
     tar xzf apache-ant-1.8.4-bin.tar.gz
     mv apache-ant-1.8.4/* .
     rmdir apache-ant-1.8.4

--- a/openjdk8-lambda/linux/build.sh
+++ b/openjdk8-lambda/linux/build.sh
@@ -40,7 +40,7 @@ function ensure_ant()
   if [ ! -x $OBF_DROP_DIR/ant/bin/ant ]; then
     mkdir -p $OBF_DROP_DIR/ant
     pushd $OBF_DROP_DIR/ant
-    curl -L http://mirrors.ircam.fr/pub/apache/ant/binaries/apache-ant-1.8.4-bin.tar.gz -o apache-ant-1.8.4-bin.tar.gz
+    curl -L http://archive.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.tar.gz -o apache-ant-1.8.4-bin.tar.gz
     tar xzf apache-ant-1.8.4-bin.tar.gz
     mv apache-ant-1.8.4/* .
     rmdir apache-ant-1.8.4

--- a/openjdk8/linux/build.sh
+++ b/openjdk8/linux/build.sh
@@ -38,7 +38,7 @@ function ensure_ant()
   if [ ! -x $OBF_DROP_DIR/ant/bin/ant ]; then
     mkdir -p $OBF_DROP_DIR/ant
     pushd $OBF_DROP_DIR/ant
-    curl -L http://mirrors.ircam.fr/pub/apache/ant/binaries/apache-ant-1.8.4-bin.tar.gz -o apache-ant-1.8.4-bin.tar.gz
+    curl -L http://archive.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.tar.gz -o apache-ant-1.8.4-bin.tar.gz
     tar xzf apache-ant-1.8.4-bin.tar.gz
     mv apache-ant-1.8.4/* .
     rmdir apache-ant-1.8.4


### PR DESCRIPTION
No sure this is still used by the new build system but ....
