### PR TITLE
Add XDEBUG_BINARIES to allow overrriding DEBUG_BINARIES but still preser...

### DIFF
--- a/openjdk8/linux/build.sh
+++ b/openjdk8/linux/build.sh
@@ -254,8 +254,12 @@ function build_new()
   if [ "$XCLEAN" = "true" ]; then
       CONT=$BUILD_PROFILE make clean
   fi
-
-  CONT=$BUILD_PROFILE make EXTRA_CFLAGS=$EXTRA_CFLAGS DEBUG_BINARIES=true images
+	
+  if [ "$XDEBUG_BINARIES" = "false" ]; then
+      CONT=$BUILD_PROFILE make EXTRA_CFLAGS=$EXTRA_CFLAGS DEBUG_BINARIES=false images
+  else
+      CONT=$BUILD_PROFILE make EXTRA_CFLAGS=$EXTRA_CFLAGS DEBUG_BINARIES=true images
+  fi
 
   popd >>/dev/null
 

--- a/openjdk9/linux/build.sh
+++ b/openjdk9/linux/build.sh
@@ -259,7 +259,11 @@ function build_new()
       CONT=$BUILD_PROFILE make clean
   fi
 
-  CONT=$BUILD_PROFILE make DEBUG_BINARIES=true EXTRA_CFLAGS=$EXTRA_CFLAGS images
+  if [ "$XDEBUG_BINARIES = "false" ]; then
+      CONT=$BUILD_PROFILE make DEBUG_BINARIES=false EXTRA_CFLAGS=$EXTRA_CFLAGS images
+  else
+      CONT=$BUILD_PROFILE make DEBUG_BINARIES=true EXTRA_CFLAGS=$EXTRA_CFLAGS images
+  fi
 
   popd >>/dev/null
 


### PR DESCRIPTION
...ve backward compatibility for fix on commit 163c11e. See http://mail.openjdk.java.net/pipermail/core-libs-dev/2013-July/019246.html.