### PR TITLE
Add --clean flag on hgforest.sh update

### DIFF
--- a/openjdk7/linux/standalone-job.sh
+++ b/openjdk7/linux/standalone-job.sh
@@ -53,7 +53,7 @@ fi
 #
 if [ ! -z "$XUSE_TAG" ]; then
   echo "using tag $XUSE_TAG"
-  sh ./make/scripts/hgforest.sh update $XUSE_TAG
+  sh ./make/scripts/hgforest.sh update --clean $XUSE_TAG
 fi
 
 popd >>/dev/null

--- a/openjdk8/linux/standalone-job.sh
+++ b/openjdk8/linux/standalone-job.sh
@@ -53,7 +53,7 @@ fi
 #
 if [ ! -z "$XUSE_TAG" ]; then
   echo "using tag $XUSE_TAG"
-  sh ./make/scripts/hgforest.sh update $XUSE_TAG
+  sh ./make/scripts/hgforest.sh update --clean $XUSE_TAG
 fi
 
 popd >>/dev/null

--- a/openjdk9/linux/standalone-job.sh
+++ b/openjdk9/linux/standalone-job.sh
@@ -53,7 +53,7 @@ fi
 #
 if [ ! -z "$XUSE_TAG" ]; then
   echo "using tag $XUSE_TAG"
-  sh ./make/scripts/hgforest.sh update $XUSE_TAG
+  sh ./make/scripts/hgforest.sh update --clean $XUSE_TAG
 fi
 
 popd >>/dev/null


### PR DESCRIPTION
In some cases the previous build might have changed some files preventing update to working normally if another build is made without wiping the source files. This will make the hg update process discard every uncommitted change.