### PR TITLE
Fix scripts for building OpenJDK 8 and 9 on OS X

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -21,7 +21,7 @@ function apply_patches()
       patch -f -p0 <$i
     done
   fi
-  
+
   popd >>/dev/null
 }
 
@@ -32,7 +32,7 @@ function cacerts_gen()
 {
   local DESTCERTS=$1
   local TMPCERTSDIR=`mktemp -d certs`
-  
+
   pushd $TMPCERTSDIR
   curl -L http://curl.haxx.se/ca/cacert.pem -o cacert.pem
   cat cacert.pem | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/{ print $0; }' > cacert-clean.pem
@@ -40,7 +40,7 @@ function cacerts_gen()
   split  -p "-----BEGIN CERTIFICATE-----" cacert-clean.pem cert_
 
   export JAVA_HOME=`/usr/libexec/java_home -v 1.6`
-  
+
   for CERT_FILE in cert_*; do
     ALIAS=$(basename ${CERT_FILE})
     echo yes | keytool -import -alias ${ALIAS} -keystore cacerts -storepass 'changeit' -file ${CERT_FILE} || :
@@ -48,7 +48,7 @@ function cacerts_gen()
   done
 
   unset JAVA_HOME
-  
+
   rm -f cacert.pem cacert-clean.pem
   mv cacerts $DESTCERTS
 
@@ -65,8 +65,7 @@ function ensure_cacert()
     echo "no cacerts found, regenerate it..."
     cacerts_gen $OBF_DROP_DIR/cacerts
   else
-    if test `find "$OBF_DROP_DIR/cacerts" -mtime +7`
-    then
+    if test `find "$OBF_DROP_DIR/cacerts" -mtime +7`; then
       echo "cacerts older than one week, regenerate it..."
       cacerts_gen $OBF_DROP_DIR/cacerts
     fi
@@ -79,39 +78,39 @@ function ensure_cacert()
 function ensure_freetype()
 {
   if [ ! -f $OBF_DROP_DIR/freetype/lib/libfreetype.dylib ]; then
-	  
-	  FREETYPE_VERSION=2.4.10
 
-	  if [ ! -f $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2 ]; then
-	    curl -L http://download.savannah.gnu.org/releases/freetype/freetype-$FREETYPE_VERSION.tar.bz2 -o $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2
-	  fi
+    FREETYPE_VERSION=2.4.10
 
-	  if [ ! -d $OBF_DROP_DIR/freetype-patches ]; then
-	    mkdir -p $OBF_DROP_DIR/freetype-patches
-	    curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-modules.cfg.diff -o $OBF_DROP_DIR/freetype-patches/patch-modules.cfg.diff
-	    curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-src_base_ftrfork.c.diff -o $OBF_DROP_DIR/freetype-patches/patch-src_base_ftrfork.c.diff
-	  fi
+    if [ ! -f $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2 ]; then
+      curl -L http://download.savannah.gnu.org/releases/freetype/freetype-$FREETYPE_VERSION.tar.bz2 -o $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2
+    fi
 
-	  rm -rf freetype-$FREETYPE_VERSION
-	  rm -rf $OBF_DROP_DIR/freetype
+    if [ ! -d $OBF_DROP_DIR/freetype-patches ]; then
+      mkdir -p $OBF_DROP_DIR/freetype-patches
+      curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-modules.cfg.diff -o $OBF_DROP_DIR/freetype-patches/patch-modules.cfg.diff
+      curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-src_base_ftrfork.c.diff -o $OBF_DROP_DIR/freetype-patches/patch-src_base_ftrfork.c.diff
+    fi
 
-	  tar xvjf $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2
-	  pushd freetype-$FREETYPE_VERSION >>/dev/null
+    rm -rf freetype-$FREETYPE_VERSION
+    rm -rf $OBF_DROP_DIR/freetype
 
-	  for i in $OBF_DROP_DIR/freetype-patches/*; do
-	    echo "applying patch $i"
-	    patch -p0 <$i
-	  done
+    tar xvjf $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2
+    pushd freetype-$FREETYPE_VERSION >>/dev/null
 
-	  ./configure --prefix=$OBF_DROP_DIR/freetype CC=/usr/bin/clang 'CFLAGS=-pipe -Os -arch i386 -arch x86_64' \
+    for i in $OBF_DROP_DIR/freetype-patches/*; do
+      echo "applying patch $i"
+      patch -p0 <$i
+    done
+
+    ./configure --prefix=$OBF_DROP_DIR/freetype CC=/usr/bin/clang 'CFLAGS=-pipe -Os -arch i386 -arch x86_64' \
       'LDFLAGS=-arch i386 -arch x86_64' CXX=/usr/bin/clang++ 'CXXFLAGS=-pipe -Os -arch i386 -arch x86_64' \
       --disable-static --with-old-mac-fonts
-	  make install
+    make install
 
-	  cp $OBF_DROP_DIR/freetype/lib/libfreetype.6.dylib $OBF_DROP_DIR/freetype/lib/libfreetype.dylib
+    cp $OBF_DROP_DIR/freetype/lib/libfreetype.6.dylib $OBF_DROP_DIR/freetype/lib/libfreetype.dylib
 
-	  popd >>/dev/null
-	  rm -rf freetype-$FREETYPE_VERSION
+    popd >>/dev/null
+    rm -rf freetype-$FREETYPE_VERSION
 
   fi
 
@@ -119,33 +118,32 @@ function ensure_freetype()
     export ALT_FREETYPE_LIB_PATH=$OBF_DROP_DIR/freetype/lib
     export ALT_FREETYPE_HEADERS_PATH=$OBF_DROP_DIR/freetype/include
   fi
-  
+
 }
 
 function check_version()
 {
-    local version=$1 check=$2
-    local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -nr | head -1)
-    [[ "$winner" = "$version" ]] && return 0
-    return 1
+  local version=$1 check=$2
+  local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -nr | head -1)
+  [[ "$winner" = "$version" ]] && return 0
+  return 1
 }
 
 #
 # Build using old build system
-# 
+#
 function build_old()
 {
   echo "### using old build system ###"
-  
+
   NUM_CPUS=`sysctl -n hw.ncpu`
 
   export MILESTONE="$OBF_BUILD_NUMBER"
   export BUILD_NUMBER="$OBF_BUILD_DATE"
-  
+
   export LD_LIBRARY_PATH=
   if [ -z "$ALT_BOOTDIR" ]; then
-    if [ -z "$JAVA_HOME" ];
-    then
+    if [ -z "$JAVA_HOME" ]; then
       export ALT_BOOTDIR=`/usr/libexec/java_home -v 1.7`
     else
       export ALT_BOOTDIR=$JAVA_HOME
@@ -165,24 +163,24 @@ function build_old()
   fi
 
   case $OBF_BASE_ARCH in
-  	x86_64)
-		export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-x86_64
-  	;;
-  	i386)
-  		export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-i586
-  	;;
-  	universal)
-  		export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-universal
-  	;;
+    x86_64)
+      export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-x86_64
+    ;;
+    i386)
+      export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-i586
+    ;;
+    universal)
+      export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-universal
+    ;;
   esac
-  
+
   if [ "$XCLEAN" = "true" ]; then
-	  rm -rf $IMAGE_BUILD_DIR
+    rm -rf $IMAGE_BUILD_DIR
   fi
-  
+
   # Set Company Name to OBuildFactory
   sed -i "" -e "s|COMPANY_NAME = N/A|COMPANY_NAME = $BUNDLE_VENDOR|g" $OBF_SOURCES_PATH/jdk/make/common/shared/Defs.gmk
-  
+
   pushd $OBF_SOURCES_PATH >>/dev/null
   make ALLOW_DOWNLOADS=true SA_APPLE_BOOT_JAVA=true ALWAYS_PASS_TEST_GAMMA=true ALT_BOOTDIR=$ALT_BOOTDIR ALT_DROPS_DIR=$DROP_DIR HOTSPOT_BUILD_JOBS=$NUM_CPUS PARALLEL_COMPILE_JOBS=$NUM_CPUS
   popd >>/dev/null
@@ -190,140 +188,139 @@ function build_old()
 
 #
 # Build using new build system
-# 
+#
 function build_new()
 {
-    echo "### using new build system ###"
+  echo "### using new build system ###"
 
-    # ensure makefiles dir exists
-    mkdir -p $OBF_SOURCES_PATH/common/makefiles
-    pushd $OBF_SOURCES_PATH/common/makefiles >>/dev/null
-  
-    # patch common/autoconf/version-numbers
-    mv ../autoconf/version-numbers ../autoconf/version-numbers.orig 
-    cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
+  # ensure makefiles dir exists
+  mkdir -p $OBF_SOURCES_PATH/common/makefiles
+  pushd $OBF_SOURCES_PATH/common/makefiles >>/dev/null
 
-    export JDK_BUILD_NUMBER=$OBF_BUILD_DATE
-    export MILESTONE=$OBF_MILESTONE
-    export COMPANY_NAME=$BUNDLE_VENDOR
+  # patch common/autoconf/version-numbers
+  mv ../autoconf/version-numbers ../autoconf/version-numbers.orig
+  cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
 
-    if [ -z "$JAVA_HOME" ];
-    then
-      export OBF_BOOTDIR=`/usr/libexec/java_home -v 1.7`
-    else
-      export OBF_BOOTDIR=$JAVA_HOME
-    fi
-    OBF_BOOTDIR=`/usr/libexec/java_home -v 1.7`
-	
-    rm -rf $OBF_WORKSPACE_PATH/.ccache
-    mkdir -p $OBF_WORKSPACE_PATH/.ccache
+  export JDK_BUILD_NUMBER=$OBF_BUILD_DATE
+  export MILESTONE=$OBF_MILESTONE
+  export COMPANY_NAME=$BUNDLE_VENDOR
 
-    if [ "$XDEBUG" = "true" ]; then
+  if [ -z "$JAVA_HOME" ]; then
+    export OBF_BOOTDIR=`/usr/libexec/java_home -v 1.7`
+  else
+    export OBF_BOOTDIR=$JAVA_HOME
+  fi
+  OBF_BOOTDIR=`/usr/libexec/java_home -v 1.7`
 
-	    case $OBF_BASE_ARCH in
-	    	x86_64)
-			    BUILD_PROFILE=macosx-x86_64-normal-server-fastdebug
-	    	;;
-	    	i386)
-		        BUILD_PROFILE=macosx-x86-normal-server-fastdebug
-	    	;;
-	    	universal)
-	            BUILD_PROFILE=macosx-universal-normal-server-fastdebug
-	    	;;
-	    esac
+  rm -rf $OBF_WORKSPACE_PATH/.ccache
+  mkdir -p $OBF_WORKSPACE_PATH/.ccache
 
-#	    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
-	    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
+  if [ "$XDEBUG" = "true" ]; then
 
-	else
+    case $OBF_BASE_ARCH in
+      x86_64)
+        BUILD_PROFILE=macosx-x86_64-normal-server-fastdebug
+      ;;
+      i386)
+        BUILD_PROFILE=macosx-x86-normal-server-fastdebug
+      ;;
+      universal)
+        BUILD_PROFILE=macosx-universal-normal-server-fastdebug
+      ;;
+    esac
 
-	    case $OBF_BASE_ARCH in
-	    	x86_64)
-		        BUILD_PROFILE=macosx-x86_64-normal-server-release
-	    	;;
-	    	i386)
-	            BUILD_PROFILE=macosx-x86-normal-server-release
-	    	;;
-	    	universal)
-            	BUILD_PROFILE=macosx-universal-normal-server-release
-	    	;;
-	    esac
+    # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
+    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
 
-#	    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
-	    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
-    fi
+  else
 
-    export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/$BUILD_PROFILE/images
-	
-	if [ "$XCLEAN" = "true" ]; then
-#  	   CONF=$BUILD_PROFILE make clean
-  	   make clean
-    fi
+    case $OBF_BASE_ARCH in
+      x86_64)
+        BUILD_PROFILE=macosx-x86_64-normal-server-release
+      ;;
+      i386)
+        BUILD_PROFILE=macosx-x86-normal-server-release
+      ;;
+      universal)
+        BUILD_PROFILE=macosx-universal-normal-server-release
+      ;;
+    esac
 
-#    CONF=$BUILD_PROFILE make images
-    make images
-    
-    # restore original common/autoconf/version-numbers
-    mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+    # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
+    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
+  fi
 
-    popd >>/dev/null
+  export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/$BUILD_PROFILE/images
+
+  if [ "$XCLEAN" = "true" ]; then
+    # CONF=$BUILD_PROFILE make clean
+    make clean
+  fi
+
+  # CONF=$BUILD_PROFILE make images
+  make images
+
+  # restore original common/autoconf/version-numbers
+  mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+
+  popd >>/dev/null
 }
 
 #
-# Verify build 
+# Verify build
 #
 function test_build()
 {
   if [ -x $IMAGE_BUILD_DIR/j2sdk-image/bin/java ]; then
     $IMAGE_BUILD_DIR/j2sdk-image/bin/java -version
   else
-    echo "can't find java into JDK $IMAGE_BUILD_DIR/j2sdk-image/bin, build failed" 
+    echo "can't find java into JDK $IMAGE_BUILD_DIR/j2sdk-image/bin, build failed"
     exit -1
-   fi
+  fi
 
-   if [ -x $IMAGE_BUILD_DIR/j2re-image/bin/java ]; then
-     $IMAGE_BUILD_DIR/j2re-image/bin/java -version
-   else
-     echo "can't find java into JRE $IMAGE_BUILD_DIR/j2re-image/bin, build failed" 
-     exit -1
-    fi
+  if [ -x $IMAGE_BUILD_DIR/j2re-image/bin/java ]; then
+    $IMAGE_BUILD_DIR/j2re-image/bin/java -version
+  else
+    echo "can't find java into JRE $IMAGE_BUILD_DIR/j2re-image/bin, build failed"
+    exit -1
+  fi
 }
 
 #
-# Archives build 
+# Archives build
 #
 function archive_build()
 {
-    mkdir -p $OBF_DROP_DIR/$OBF_PROJECT_NAME
+  mkdir -p $OBF_DROP_DIR/$OBF_PROJECT_NAME
 
-    pushd $IMAGE_BUILD_DIR >>/dev/null
-	
-    if [ "$XDEBUG" = "true" ]; then
-    	FILENAME_PREFIX="-fastdebug"
-    fi
-	
-    tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2sdk-image$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 j2sdk-image
-    tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2re-image$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 j2re-image
-	popd >>/dev/null
+  pushd $IMAGE_BUILD_DIR >>/dev/null
 
-	if [ -d $IMAGE_BUILD_DIR/j2sdk-bundle ]; then
-		pushd $IMAGE_BUILD_DIR/j2sdk-bundle >>/dev/null
-		tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2sdk-bundle$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jdk1.8.0.jdk
-		popd >>/dev/null
-	else
-		echo "Warning, j2sdk bundle not found, DMG packages won't be available"
-  	fi
-	
-	if [ -d $IMAGE_BUILD_DIR/j2re-bundle ]; then
-		pushd $IMAGE_BUILD_DIR/j2re-bundle >>/dev/null
-		tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2re-bundle$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jre1.8.0.jre
-		popd >>/dev/null
-	else
-		echo "Warning, j2re bundle not found, DMG packages won't be available"
-	fi
-	
-    echo "produced tarball files under $OBF_DROP_DIR/$OBF_PROJECT_NAME"
-    ls -l $OBF_DROP_DIR/$OBF_PROJECT_NAME/*$OBF_BUILD_NUMBER-$OBF_BUILD_DATE*
+  if [ "$XDEBUG" = "true" ]; then
+    FILENAME_PREFIX="-fastdebug"
+  fi
+
+  tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2sdk-image$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 j2sdk-image
+  tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2re-image$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 j2re-image
+  popd >>/dev/null
+
+  if [ -d $IMAGE_BUILD_DIR/j2sdk-bundle ]; then
+    pushd $IMAGE_BUILD_DIR/j2sdk-bundle >>/dev/null
+    tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2sdk-bundle$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jdk1.8.0.jdk
+    popd >>/dev/null
+  else
+    echo "Warning, j2sdk bundle not found, DMG packages won't be available"
+  fi
+
+  if [ -d $IMAGE_BUILD_DIR/j2re-bundle ]; then
+    pushd $IMAGE_BUILD_DIR/j2re-bundle >>/dev/null
+    tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2re-bundle$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jre1.8.0.jre
+    popd >>/dev/null
+  else
+    echo "Warning, j2re bundle not found, DMG packages won't be available"
+  fi
+
+  echo "produced tarball files under $OBF_DROP_DIR/$OBF_PROJECT_NAME"
+  ls -l $OBF_DROP_DIR/$OBF_PROJECT_NAME/*$OBF_BUILD_NUMBER-$OBF_BUILD_DATE*
 }
 
 #
@@ -358,7 +355,7 @@ if [ "$XUSE_NEW_BUILD_SYSTEM" = "true" ]; then
 else
   build_old
 fi
-	  
+
 #
 # Test Build
 #

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -194,14 +194,12 @@ function build_new()
 {
   echo "### using new build system ###"
 
-  # ensure makefiles dir exists
-  mkdir -p $OBF_SOURCES_PATH/common/makefiles
-  pushd $OBF_SOURCES_PATH/common/makefiles >>/dev/null
+  pushd $OBF_SOURCES_PATH >>/dev/null
 
-  # patch ../autoconf/version-numbers
-  if [ -f ../autoconf/version-numbers ]; then
-    mv ../autoconf/version-numbers ../autoconf/version-numbers.orig
-    cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
+  # patch common/autoconf/version-numbers
+  if [ -f common/autoconf/version-numbers ]; then
+    mv common/autoconf/version-numbers common/autoconf/version-numbers.orig
+    cat common/autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > common/autoconf/version-numbers
   fi
 
   export JDK_BUILD_NUMBER=$OBF_BUILD_DATE
@@ -232,8 +230,12 @@ function build_new()
       ;;
     esac
 
+    rm -rf $OBF_SOURCES_PATH/build/$BUILD_PROFILE
+    mkdir -p $OBF_SOURCES_PATH/build/$BUILD_PROFILE
+    pushd $OBF_SOURCES_PATH/build/$BUILD_PROFILE >>/dev/null
+
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
-    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE \
         --enable-debug
@@ -252,8 +254,10 @@ function build_new()
       ;;
     esac
 
+    pushd $OBF_SOURCES_PATH/build/$BUILD_PROFILE >>/dev/null
+
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
-    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE
   fi
@@ -268,9 +272,11 @@ function build_new()
   # CONF=$BUILD_PROFILE make images
   make images
 
-  # restore original ../autoconf/version-numbers
-  if [ -f ../autoconf/version-numbers.orig ]; then
-    mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+  popd >>/dev/null
+
+  # restore original common/autoconf/version-numbers
+  if [ -f common/autoconf/version-numbers.orig ]; then
+    mv common/autoconf/version-numbers.orig common/autoconf/version-numbers
   fi
 
   popd >>/dev/null

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -272,7 +272,7 @@ function build_new()
   fi
 
   # CONF=$BUILD_PROFILE make images
-  make images
+  make DEBUG_BINARIES=${XDEBUG_BINARIES:-false} images
 
   popd >>/dev/null
 

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -197,9 +197,11 @@ function build_new()
   mkdir -p $OBF_SOURCES_PATH/common/makefiles
   pushd $OBF_SOURCES_PATH/common/makefiles >>/dev/null
 
-  # patch common/autoconf/version-numbers
-  mv ../autoconf/version-numbers ../autoconf/version-numbers.orig
-  cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
+  # patch ../autoconf/version-numbers
+  if [ -f ../autoconf/version-numbers ]; then
+    mv ../autoconf/version-numbers ../autoconf/version-numbers.orig
+    cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
+  fi
 
   export JDK_BUILD_NUMBER=$OBF_BUILD_DATE
   export MILESTONE=$OBF_MILESTONE
@@ -260,8 +262,10 @@ function build_new()
   # CONF=$BUILD_PROFILE make images
   make images
 
-  # restore original common/autoconf/version-numbers
-  mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+  # restore original ../autoconf/version-numbers
+  if [ -f ../autoconf/version-numbers.orig ]; then
+    mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+  fi
 
   popd >>/dev/null
 }

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -137,6 +137,7 @@ function build_old()
   echo "### using old build system ###"
 
   NUM_CPUS=`sysctl -n hw.ncpu`
+  [ $NUM_CPUS -gt 8 ] && NUM_CPUS=8
 
   export MILESTONE="$OBF_BUILD_NUMBER"
   export BUILD_NUMBER="$OBF_BUILD_DATE"

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -237,7 +237,7 @@ function build_new()
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
     sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
-        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE \
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
         --enable-debug
 
   else
@@ -261,7 +261,7 @@ function build_new()
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
     sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
-        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER
   fi
 
   export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/$BUILD_PROFILE/images

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -240,6 +240,7 @@ function build_new()
         --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
+        --enable-unlimited-crypto=yes \
         --enable-debug
 
   else
@@ -265,7 +266,8 @@ function build_new()
         --with-xcode-path=$OBF_XCODE_PATH \
         --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
-        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
+        --enable-unlimited-crypto=yes
   fi
 
   export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/$BUILD_PROFILE/images

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -235,7 +235,9 @@ function build_new()
     pushd $OBF_SOURCES_PATH/build/$BUILD_PROFILE >>/dev/null
 
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
-    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR \
+        --with-xcode-path=$OBF_XCODE_PATH \
+        --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
         --enable-debug
@@ -259,7 +261,9 @@ function build_new()
     pushd $OBF_SOURCES_PATH/build/$BUILD_PROFILE >>/dev/null
 
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
-    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR \
+        --with-xcode-path=$OBF_XCODE_PATH \
+        --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER
   fi

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -233,7 +233,8 @@ function build_new()
 
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
     sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
-        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --with-milestone=$OBF_MILESTONE \
+        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE \
         --enable-debug
 
   else
@@ -252,7 +253,8 @@ function build_new()
 
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
     sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
-        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --with-milestone=$OBF_MILESTONE
+        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE
   fi
 
   export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/$BUILD_PROFILE/images

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -232,7 +232,9 @@ function build_new()
     esac
 
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
-    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
+    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --with-milestone=$OBF_MILESTONE \
+        --enable-debug
 
   else
 
@@ -249,7 +251,8 @@ function build_new()
     esac
 
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
-    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
+    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --with-milestone=$OBF_MILESTONE
   fi
 
   export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/$BUILD_PROFILE/images

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -254,6 +254,8 @@ function build_new()
       ;;
     esac
 
+    rm -rf $OBF_SOURCES_PATH/build/$BUILD_PROFILE
+    mkdir -p $OBF_SOURCES_PATH/build/$BUILD_PROFILE
     pushd $OBF_SOURCES_PATH/build/$BUILD_PROFILE >>/dev/null
 
     # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache

--- a/openjdk8/macosx/build.sh
+++ b/openjdk8/macosx/build.sh
@@ -167,7 +167,7 @@ function build_old()
     x86_64)
       export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-x86_64
     ;;
-    i386)
+    x86)
       export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-i586
     ;;
     universal)
@@ -216,59 +216,27 @@ function build_new()
   rm -rf $OBF_WORKSPACE_PATH/.ccache
   mkdir -p $OBF_WORKSPACE_PATH/.ccache
 
+  BUILD_PROFILE="macosx-$OBF_BASE_ARCH-normal-server"
+
   if [ "$XDEBUG" = "true" ]; then
-
-    case $OBF_BASE_ARCH in
-      x86_64)
-        BUILD_PROFILE=macosx-x86_64-normal-server-fastdebug
-      ;;
-      i386)
-        BUILD_PROFILE=macosx-x86-normal-server-fastdebug
-      ;;
-      universal)
-        BUILD_PROFILE=macosx-universal-normal-server-fastdebug
-      ;;
-    esac
-
-    rm -rf $OBF_SOURCES_PATH/build/$BUILD_PROFILE
-    mkdir -p $OBF_SOURCES_PATH/build/$BUILD_PROFILE
-    pushd $OBF_SOURCES_PATH/build/$BUILD_PROFILE >>/dev/null
-
-    # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug
-    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR \
-        --with-xcode-path=$OBF_XCODE_PATH \
-        --with-cacerts-file=$OBF_DROP_DIR/cacerts \
-        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
-        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
-        --enable-unlimited-crypto=yes \
-        --enable-debug
-
+    BUILD_PROFILE+="-fastdebug"
+    EXTRA_CONF_OPTS="--enable-debug"
   else
-
-    case $OBF_BASE_ARCH in
-      x86_64)
-        BUILD_PROFILE=macosx-x86_64-normal-server-release
-      ;;
-      i386)
-        BUILD_PROFILE=macosx-x86-normal-server-release
-      ;;
-      universal)
-        BUILD_PROFILE=macosx-universal-normal-server-release
-      ;;
-    esac
-
-    rm -rf $OBF_SOURCES_PATH/build/$BUILD_PROFILE
-    mkdir -p $OBF_SOURCES_PATH/build/$BUILD_PROFILE
-    pushd $OBF_SOURCES_PATH/build/$BUILD_PROFILE >>/dev/null
-
-    # sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-freetype=$OBF_DROP_DIR/freetype --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache
-    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR \
-        --with-xcode-path=$OBF_XCODE_PATH \
-        --with-cacerts-file=$OBF_DROP_DIR/cacerts \
-        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
-        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
-        --enable-unlimited-crypto=yes
+    BUILD_PROFILE+="-release"
+    EXTRA_CONF_OPTS=
   fi
+
+  rm -rf $OBF_SOURCES_PATH/build/$BUILD_PROFILE
+  mkdir -p $OBF_SOURCES_PATH/build/$BUILD_PROFILE
+  pushd $OBF_SOURCES_PATH/build/$BUILD_PROFILE >>/dev/null
+
+  sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR \
+      --with-xcode-path=$OBF_XCODE_PATH \
+      --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+      --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
+      --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
+      --enable-unlimited-crypto=yes \
+      $EXTRA_CONF_OPTS
 
   export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/$BUILD_PROFILE/images
 

--- a/openjdk8/macosx/deploy.sh
+++ b/openjdk8/macosx/deploy.sh
@@ -9,7 +9,7 @@
 # OBF_BASE_PATH (ie: /home/jenkinsa/www)
 # OBF_UPLOAD_PATH (ie: /home/jenkinsa/upload)
 #
-# OBF_BASE_ARCH (i386, x86_64 or universal)
+# OBF_BASE_ARCH (x86, x86_64 or universal)
 # OBF_RELEASE_VERSION (10.6, 10.7, 10.8)
 #
 # OBF_GPG_ID (ie: packagers@obuildfactory.org)

--- a/openjdk8/macosx/jenkins-job.sh
+++ b/openjdk8/macosx/jenkins-job.sh
@@ -47,8 +47,12 @@ pushd $OBF_SOURCES_PATH >>/dev/null
 #
 # Build System concats OBF_MILESTONE, - and OBF_BUILD_DATE, ie b56-20120908
 #
-export OBF_MILESTONE=`hg tags | grep $TAG_FILTER | head -1 | cut -d ' ' -f 1 | sed 's/^-//'`
-export OBF_BUILD_NUMBER=`hg tags | grep $TAG_FILTER | head -1 | sed "s/$TAG_FILTER//" | cut -d ' ' -f 1 | sed 's/^-//'`
+export OBF_MILESTONE=`hg identify | cut -d ' ' -f 2 | cut -d '/' -f 1`
+if [ "$OBF_MILESTONE" = "tip" ]; then
+  export OBF_MILESTONE=`hg tags | grep $TAG_FILTER | head -1 | cut -d ' ' -f 1`
+fi
+
+export OBF_BUILD_NUMBER=`echo $OBF_MILESTONE | sed "s/$TAG_FILTER//" | sed 's/^-//'`
 export OBF_BUILD_DATE=`date +%Y%m%d`
 
 if [ -z "$OBF_DISTRIBUTION" ]; then

--- a/openjdk8/macosx/jenkins-job.sh
+++ b/openjdk8/macosx/jenkins-job.sh
@@ -38,6 +38,10 @@ if [ -z "$OBF_WORKSPACE_PATH" ]; then
   export OBF_WORKSPACE_PATH=`pwd`
 fi
 
+if [ -z "$OBF_XCODE_PATH" ]; then
+  export OBF_XCODE_PATH=/Application/Xcode.app
+fi
+
 pushd $OBF_SOURCES_PATH >>/dev/null
 
 #

--- a/openjdk8/macosx/jenkins-job.sh
+++ b/openjdk8/macosx/jenkins-job.sh
@@ -17,6 +17,10 @@ if [ -z $OBF_DROP_DIR ]; then
   export OBF_DROP_DIR="$HOME/OBF_DROP_DIR"
 fi
 
+if [ "$XCLEAN" = "true" ]; then
+  rm -rf $OBF_DROP_DIR
+fi
+
 mkdir -p $OBF_DROP_DIR
 
 #

--- a/openjdk8/macosx/package.sh
+++ b/openjdk8/macosx/package.sh
@@ -28,7 +28,7 @@ JRE_BUNDLE=$OBF_DROP_DIR/$OBF_PROJECT_NAME/j2re-bundle$FILENAME_PREFIX-$OBF_BASE
 # 1.8.0 to be injected in Info.plist
 JVM_VERSION=1.8.0
 
-# jdk dirname in template.dmg 
+# jdk dirname in template.dmg
 DMG_BUNDLE_DIR=1.8.0.jdk
 
 #
@@ -40,54 +40,54 @@ DMG_BUNDLE_DIR=1.8.0.jdk
 #
 function build_dmg()
 {
-    PACKAGE_NAME=$1
-    BUNDLE_FILE=$2
-    SRC_BUNDLE=$3
-    DST_BUNDLE=$4
-    FILE_NAME=$5
-  
-    pushd $OBF_BUILD_PATH/dmg >>/dev/null
+  PACKAGE_NAME=$1
+  BUNDLE_FILE=$2
+  SRC_BUNDLE=$3
+  DST_BUNDLE=$4
+  FILE_NAME=$5
 
+  pushd $OBF_BUILD_PATH/dmg >>/dev/null
+
+  rm -rf TEMP
+  mkdir -p TEMP
+
+  if [ -f $BUNDLE_FILE ]; then
+    echo "packaging $PACKAGE_NAME"
+
+    pushd TEMP >>/dev/null
+
+    tar xjf $BUNDLE_FILE
+
+    # Set Milestone and buildnumber in Info.plist
+    sed -i "" -e "s|<string>$JVM_VERSION</string>|<string>$JVM_VERSION-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE</string>|" $SRC_BUNDLE/Contents/Info.plist
+
+    cp ../template.dmg.bz2 .
+    bzip2 -d template.dmg.bz2
+
+    DMG_MOUNT_DIR=`pwd`/MOUNT_DIR
+    mkdir -p $DMG_MOUNT_DIR
+
+    hdiutil attach template.dmg -readwrite -noverify -noautoopen -noautoopenro -noautoopenrw -noautofsck -noidme -noidmereveal -noidmetrash -mountpoint $DMG_MOUNT_DIR
+
+    rm -f $DMG_MOUNT_DIR/$DMG_BUNDLE_DIR
+    mv $SRC_BUNDLE $DMG_MOUNT_DIR/$DST_BUNDLE
+    cp -f ../README $DMG_MOUNT_DIR/README
+    cp -f ../LEGAL $DMG_MOUNT_DIR/LEGAL
+
+    ../SetFileIcon -image ../logo.png -file $DMG_MOUNT_DIR/$DST_BUNDLE
+
+    hdiutil detach $DMG_MOUNT_DIR -quiet -force
+    hdiutil convert template.dmg -format UDZO -imagekey zlib-level=9 -o $FILE_NAME-$OBF_BASE_ARCH-$PACKAGE_NAME-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.dmg
+    rm template.dmg
+
+    mkdir -p $OBF_DROP_DIR/$OBF_PROJECT_NAME
+    mv $FILE_NAME-$OBF_BASE_ARCH-$PACKAGE_NAME-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.dmg $OBF_DROP_DIR/$OBF_PROJECT_NAME
+
+    popd >>/dev/null
     rm -rf TEMP
-    mkdir -p TEMP
-
-    if [ -f $BUNDLE_FILE ]; then
-      echo "packaging $PACKAGE_NAME"
-
-      pushd TEMP >>/dev/null
-
-      tar xjf $BUNDLE_FILE
-    
-      # Set Milestone and buildnumber in Info.plist
-      sed -i "" -e "s|<string>$JVM_VERSION</string>|<string>$JVM_VERSION-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE</string>|" $SRC_BUNDLE/Contents/Info.plist
-  
-      cp ../template.dmg.bz2 .
-      bzip2 -d template.dmg.bz2
-
-      DMG_MOUNT_DIR=`pwd`/MOUNT_DIR
-      mkdir -p $DMG_MOUNT_DIR
-
-      hdiutil attach template.dmg -readwrite -noverify -noautoopen -noautoopenro -noautoopenrw -noautofsck -noidme -noidmereveal -noidmetrash -mountpoint $DMG_MOUNT_DIR
-
-      rm -f $DMG_MOUNT_DIR/$DMG_BUNDLE_DIR
-      mv $SRC_BUNDLE $DMG_MOUNT_DIR/$DST_BUNDLE
-      cp -f ../README $DMG_MOUNT_DIR/README
-      cp -f ../LEGAL $DMG_MOUNT_DIR/LEGAL
-
-      ../SetFileIcon -image ../logo.png -file $DMG_MOUNT_DIR/$DST_BUNDLE
-
-      hdiutil detach $DMG_MOUNT_DIR -quiet -force
-      hdiutil convert template.dmg -format UDZO -imagekey zlib-level=9 -o $FILE_NAME-$OBF_BASE_ARCH-$PACKAGE_NAME-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.dmg
-      rm template.dmg
-  
-      mkdir -p $OBF_DROP_DIR/$OBF_PROJECT_NAME
-      mv $FILE_NAME-$OBF_BASE_ARCH-$PACKAGE_NAME-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.dmg $OBF_DROP_DIR/$OBF_PROJECT_NAME
-  
-      popd >>/dev/null
-      rm -rf TEMP
-    else
-      echo "missing $PACKAGE_NAME bundle tarball $BUNDLE_FILE, skipping packaging"
-    fi
+  else
+    echo "missing $PACKAGE_NAME bundle tarball $BUNDLE_FILE, skipping packaging"
+  fi
 }
 
 # jdk/jre

--- a/openjdk8/macosx/standalone-job.sh
+++ b/openjdk8/macosx/standalone-job.sh
@@ -25,14 +25,14 @@ fi
 if [ ! -d $OBF_SOURCES_PATH ]; then
   hg clone http://hg.openjdk.java.net/jdk8u/jdk8u $OBF_SOURCES_PATH
 else
-  pushd $OBF_SOURCES_PATH >>/dev/null	
+  pushd $OBF_SOURCES_PATH >>/dev/null
   hg update
   popd >>/dev/null
-fi	
-	
+fi
+
 pushd $OBF_SOURCES_PATH >>/dev/null
 
-# 
+#
 # Updating sources for Mercurial repo
 #
 sh ./get_source.sh

--- a/openjdk8/macosx/standalone-job.sh
+++ b/openjdk8/macosx/standalone-job.sh
@@ -46,7 +46,7 @@ fi
 #
 if [ ! -z "$XUSE_TAG" ]; then
   echo "using tag $XUSE_TAG"
-  sh ./make/scripts/hgforest.sh update $XUSE_TAG
+  sh ./make/scripts/hgforest.sh update --clean $XUSE_TAG
 fi
 
 popd >>/dev/null

--- a/openjdk8/macosx/standalone-job.sh
+++ b/openjdk8/macosx/standalone-job.sh
@@ -37,6 +37,10 @@ pushd $OBF_SOURCES_PATH >>/dev/null
 #
 sh ./get_source.sh
 
+if [ -n "$XUSE_UPDATE" ]; then
+  XUSE_TAG=`hg tags | grep "jdk8u$XUSE_UPDATE" | head -1 | cut -d ' ' -f 1`
+fi
+
 #
 # Update sources to provided tag XUSE_TAG (if defined)
 #

--- a/openjdk8/macosx/test.sh
+++ b/openjdk8/macosx/test.sh
@@ -13,7 +13,7 @@
 function ensure_jtreg()
 {
   if [ ! -f $OBF_DROP_DIR/jtreg/win32/bin/jtreg ]; then
-  
+
     JTREG_VERSION=b05
 
     if [ ! -f $OBF_DROP_DIR/jtreg-$JTREG_VERSION.zip ]; then

--- a/openjdk8/macosx/test.sh
+++ b/openjdk8/macosx/test.sh
@@ -35,34 +35,12 @@ function ensure_jtreg()
 
 ensure_jtreg
 
+BUILD_PROFILE="macosx-$OBF_BASE_ARCH-normal-server"
+
 if [ "$XDEBUG" = "true" ]; then
-
-  case $OBF_BASE_ARCH in
-    x86_64)
-      BUILD_PROFILE=macosx-x86_64-normal-server-fastdebug
-      ;;
-    i386)
-      BUILD_PROFILE=macosx-x86-normal-server-fastdebug
-      ;;
-    universal)
-      BUILD_PROFILE=macosx-universal-normal-server-fastdebug
-      ;;
-  esac
-
+  BUILD_PROFILE+="-fastdebug"
 else
-
-  case $OBF_BASE_ARCH in
-    x86_64)
-      BUILD_PROFILE=macosx-x86_64-normal-server-release
-      ;;
-    i386)
-      BUILD_PROFILE=macosx-x86-normal-server-release
-      ;;
-    universal)
-      BUILD_PROFILE=macosx-universal-normal-server-release
-      ;;
-  esac
-
+  BUILD_PROFILE+="-release"
 fi
 
 export PRODUCT_HOME=$OBF_SOURCES_PATH/build/$BUILD_PROFILE/images/j2sdk-image

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -224,6 +224,7 @@ function build_new()
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
+        --enable-unlimited-crypto=yes \
         --enable-debug
 
   else
@@ -233,7 +234,8 @@ function build_new()
         --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
-        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
+        --enable-unlimited-crypto=yes
   fi
 
   export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/common/makefiles/images

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -21,7 +21,7 @@ function apply_patches()
       patch -f -p0 <$i
     done
   fi
-  
+
   popd >>/dev/null
 }
 
@@ -32,7 +32,7 @@ function cacerts_gen()
 {
   local DESTCERTS=$1
   local TMPCERTSDIR=`mktemp -d certs`
-  
+
   pushd $TMPCERTSDIR
   curl -L http://curl.haxx.se/ca/cacert.pem -o cacert.pem
   cat cacert.pem | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/{ print $0; }' > cacert-clean.pem
@@ -40,7 +40,7 @@ function cacerts_gen()
   split  -p "-----BEGIN CERTIFICATE-----" cacert-clean.pem cert_
 
   export JAVA_HOME=`/usr/libexec/java_home -v 1.6`
-  
+
   for CERT_FILE in cert_*; do
     ALIAS=$(basename ${CERT_FILE})
     echo yes | keytool -import -alias ${ALIAS} -keystore cacerts -storepass 'changeit' -file ${CERT_FILE} || :
@@ -48,7 +48,7 @@ function cacerts_gen()
   done
 
   unset JAVA_HOME
-  
+
   rm -f cacert.pem cacert-clean.pem
   mv cacerts $DESTCERTS
 
@@ -65,8 +65,7 @@ function ensure_cacert()
     echo "no cacerts found, regenerate it..."
     cacerts_gen $OBF_DROP_DIR/cacerts
   else
-    if test `find "$OBF_DROP_DIR/cacerts" -mtime +7`
-    then
+    if test `find "$OBF_DROP_DIR/cacerts" -mtime +7`; then
       echo "cacerts older than one week, regenerate it..."
       cacerts_gen $OBF_DROP_DIR/cacerts
     fi
@@ -79,39 +78,39 @@ function ensure_cacert()
 function ensure_freetype()
 {
   if [ ! -f $OBF_DROP_DIR/freetype/lib/libfreetype.dylib ]; then
-	  
-	  FREETYPE_VERSION=2.4.12
 
-	  if [ ! -f $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2 ]; then
-	    curl -L http://download.savannah.gnu.org/releases/freetype/freetype-$FREETYPE_VERSION.tar.bz2 -o $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2
-	  fi
+    FREETYPE_VERSION=2.4.12
 
-	  if [ ! -d $OBF_DROP_DIR/freetype-patches ]; then
-	    mkdir -p $OBF_DROP_DIR/freetype-patches
-	    curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-modules.cfg.diff -o $OBF_DROP_DIR/freetype-patches/patch-modules.cfg.diff
-	    curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-src_base_ftrfork.c.diff -o $OBF_DROP_DIR/freetype-patches/patch-src_base_ftrfork.c.diff
-	  fi
+    if [ ! -f $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2 ]; then
+      curl -L http://download.savannah.gnu.org/releases/freetype/freetype-$FREETYPE_VERSION.tar.bz2 -o $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2
+    fi
 
-	  rm -rf freetype-$FREETYPE_VERSION
-	  rm -rf $OBF_DROP_DIR/freetype
+    if [ ! -d $OBF_DROP_DIR/freetype-patches ]; then
+      mkdir -p $OBF_DROP_DIR/freetype-patches
+      curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-modules.cfg.diff -o $OBF_DROP_DIR/freetype-patches/patch-modules.cfg.diff
+      curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-src_base_ftrfork.c.diff -o $OBF_DROP_DIR/freetype-patches/patch-src_base_ftrfork.c.diff
+    fi
 
-	  tar xvjf $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2
-	  pushd freetype-$FREETYPE_VERSION >>/dev/null
+    rm -rf freetype-$FREETYPE_VERSION
+    rm -rf $OBF_DROP_DIR/freetype
 
-	  for i in $OBF_DROP_DIR/freetype-patches/*; do
-	    echo "applying patch $i"
-	    patch -p0 <$i
-	  done
+    tar xvjf $OBF_DROP_DIR/freetype-$FREETYPE_VERSION.tar.bz2
+    pushd freetype-$FREETYPE_VERSION >>/dev/null
 
-	  ./configure --prefix=$OBF_DROP_DIR/freetype CC=/usr/bin/clang 'CFLAGS=-pipe -Os -arch i386 -arch x86_64' \
+    for i in $OBF_DROP_DIR/freetype-patches/*; do
+      echo "applying patch $i"
+      patch -p0 <$i
+    done
+
+    ./configure --prefix=$OBF_DROP_DIR/freetype CC=/usr/bin/clang 'CFLAGS=-pipe -Os -arch i386 -arch x86_64' \
       'LDFLAGS=-arch i386 -arch x86_64' CXX=/usr/bin/clang++ 'CXXFLAGS=-pipe -Os -arch i386 -arch x86_64' \
       --disable-static --with-old-mac-fonts
-	  make install
+    make install
 
-	  cp $OBF_DROP_DIR/freetype/lib/libfreetype.6.dylib $OBF_DROP_DIR/freetype/lib/libfreetype.dylib
+    cp $OBF_DROP_DIR/freetype/lib/libfreetype.6.dylib $OBF_DROP_DIR/freetype/lib/libfreetype.dylib
 
-	  popd >>/dev/null
-	  rm -rf freetype-$FREETYPE_VERSION
+    popd >>/dev/null
+    rm -rf freetype-$FREETYPE_VERSION
 
   fi
 
@@ -119,33 +118,32 @@ function ensure_freetype()
     export ALT_FREETYPE_LIB_PATH=$OBF_DROP_DIR/freetype/lib
     export ALT_FREETYPE_HEADERS_PATH=$OBF_DROP_DIR/freetype/include
   fi
-  
+
 }
 
 function check_version()
 {
-    local version=$1 check=$2
-    local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -nr | head -1)
-    [[ "$winner" = "$version" ]] && return 0
-    return 1
+  local version=$1 check=$2
+  local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -nr | head -1)
+  [[ "$winner" = "$version" ]] && return 0
+  return 1
 }
 
 #
 # Build using old build system
-# 
+#
 function build_old()
 {
   echo "### using old build system ###"
-  
+
   NUM_CPUS=`sysctl -n hw.ncpu`
 
   export MILESTONE="$OBF_BUILD_NUMBER"
   export BUILD_NUMBER="$OBF_BUILD_DATE"
-  
+
   export LD_LIBRARY_PATH=
   if [ -z "$ALT_BOOTDIR" ]; then
-    if [ -z "$JAVA_HOME" ];
-    then
+    if [ -z "$JAVA_HOME" ]; then
       export ALT_BOOTDIR=`/usr/libexec/java_home -v 1.8`
     else
       export ALT_BOOTDIR=$JAVA_HOME
@@ -165,24 +163,24 @@ function build_old()
   fi
 
   case $OBF_BASE_ARCH in
-  	x86_64)
-		export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-x86_64
-  	;;
-  	i386)
-  		export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-i586
-  	;;
-  	universal)
-  		export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-universal
-  	;;
+    x86_64)
+      export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-x86_64
+    ;;
+    i386)
+      export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-i586
+    ;;
+    universal)
+      export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/macosx-universal
+    ;;
   esac
-  
+
   if [ "$XCLEAN" = "true" ]; then
-	  rm -rf $IMAGE_BUILD_DIR
+    rm -rf $IMAGE_BUILD_DIR
   fi
-  
+
   # Set Company Name to OBuildFactory
   sed -i "" -e "s|COMPANY_NAME = N/A|COMPANY_NAME = $BUNDLE_VENDOR|g" $OBF_SOURCES_PATH/jdk/make/common/shared/Defs.gmk
-  
+
   pushd $OBF_SOURCES_PATH >>/dev/null
   make ALLOW_DOWNLOADS=true SA_APPLE_BOOT_JAVA=true ALWAYS_PASS_TEST_GAMMA=true ALT_BOOTDIR=$ALT_BOOTDIR ALT_DROPS_DIR=$DROP_DIR HOTSPOT_BUILD_JOBS=$NUM_CPUS PARALLEL_COMPILE_JOBS=$NUM_CPUS
   popd >>/dev/null
@@ -190,113 +188,112 @@ function build_old()
 
 #
 # Build using new build system
-# 
+#
 function build_new()
 {
-    echo "### using new build system ###"
+  echo "### using new build system ###"
 
-    # ensure makefiles dir exists
-    mkdir -p $OBF_SOURCES_PATH/common/makefiles
-    pushd $OBF_SOURCES_PATH/common/makefiles >>/dev/null
-  
-    # patch common/autoconf/version-numbers
-    mv ../autoconf/version-numbers ../autoconf/version-numbers.orig 
-    cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
+  # ensure makefiles dir exists
+  mkdir -p $OBF_SOURCES_PATH/common/makefiles
+  pushd $OBF_SOURCES_PATH/common/makefiles >>/dev/null
 
-    export JDK_BUILD_NUMBER=$OBF_BUILD_DATE
-    export MILESTONE=$OBF_MILESTONE
-    export COMPANY_NAME=$BUNDLE_VENDOR
+  # patch common/autoconf/version-numbers
+  mv ../autoconf/version-numbers ../autoconf/version-numbers.orig
+  cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
 
-    if [ -z "$JAVA_HOME" ];
-    then
-      export OBF_BOOTDIR=`/usr/libexec/java_home -v 1.8`
-    else
-      export OBF_BOOTDIR=$JAVA_HOME
-    fi
-    OBF_BOOTDIR=`/usr/libexec/java_home -v 1.8`
-	
-    rm -rf $OBF_WORKSPACE_PATH/.ccache
-    mkdir -p $OBF_WORKSPACE_PATH/.ccache
+  export JDK_BUILD_NUMBER=$OBF_BUILD_DATE
+  export MILESTONE=$OBF_MILESTONE
+  export COMPANY_NAME=$BUNDLE_VENDOR
 
-    if [ "$XDEBUG" = "true" ]; then
+  if [ -z "$JAVA_HOME" ]; then
+    export OBF_BOOTDIR=`/usr/libexec/java_home -v 1.8`
+  else
+    export OBF_BOOTDIR=$JAVA_HOME
+  fi
+  OBF_BOOTDIR=`/usr/libexec/java_home -v 1.8`
 
-	    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include
+  rm -rf $OBF_WORKSPACE_PATH/.ccache
+  mkdir -p $OBF_WORKSPACE_PATH/.ccache
 
-	else
+  if [ "$XDEBUG" = "true" ]; then
 
-	    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
-	       --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include
-    fi
+    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include
 
-    export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/common/makefiles/images
-	
-    if [ "$XCLEAN" = "true" ]; then
-  	   make clean
-    fi
+  else
 
-    make images
-    
-    # restore original common/autoconf/version-numbers
-    mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
+       --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include
+  fi
 
-    popd >>/dev/null
+  export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/common/makefiles/images
+
+  if [ "$XCLEAN" = "true" ]; then
+     make clean
+  fi
+
+  make images
+
+  # restore original common/autoconf/version-numbers
+  mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+
+  popd >>/dev/null
 }
 
 #
-# Verify build 
+# Verify build
 #
 function test_build()
 {
   if [ -x $IMAGE_BUILD_DIR/jdk/bin/java ]; then
     $IMAGE_BUILD_DIR/jdk/bin/java -version
   else
-    echo "can't find java into JDK $IMAGE_BUILD_DIR/jdk/bin, build failed" 
+    echo "can't find java into JDK $IMAGE_BUILD_DIR/jdk/bin, build failed"
     exit -1
-   fi
+  fi
 
-   if [ -x $IMAGE_BUILD_DIR/jre/bin/java ]; then
-     $IMAGE_BUILD_DIR/jre/bin/java -version
-   else
-     echo "can't find java into JRE $IMAGE_BUILD_DIR/jre/bin, build failed" 
-     exit -1
-    fi
+  if [ -x $IMAGE_BUILD_DIR/jre/bin/java ]; then
+    $IMAGE_BUILD_DIR/jre/bin/java -version
+  else
+    echo "can't find java into JRE $IMAGE_BUILD_DIR/jre/bin, build failed"
+    exit -1
+  fi
 }
 
 #
-# Archives build 
+# Archives build
 #
 function archive_build()
 {
-    mkdir -p $OBF_DROP_DIR/$OBF_PROJECT_NAME
+  mkdir -p $OBF_DROP_DIR/$OBF_PROJECT_NAME
 
-    pushd $IMAGE_BUILD_DIR >>/dev/null
-	
-    if [ "$XDEBUG" = "true" ]; then
-    	FILENAME_PREFIX="-fastdebug"
-    fi
-	
-    tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/jdk$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jdk
-    tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/jre$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jre
-	popd >>/dev/null
+  pushd $IMAGE_BUILD_DIR >>/dev/null
 
-	if [ -d $IMAGE_BUILD_DIR/j2sdk-bundle ]; then
-		pushd $IMAGE_BUILD_DIR/j2sdk-bundle >>/dev/null
-		tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2sdk-bundle$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jdk1.9.0.jdk
-		popd >>/dev/null
-	else
-		echo "Warning, j2sdk bundle not found, DMG packages won't be available"
-  	fi
-	
-	if [ -d $IMAGE_BUILD_DIR/j2re-bundle ]; then
-		pushd $IMAGE_BUILD_DIR/j2re-bundle >>/dev/null
-		tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2re-bundle$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jre1.9.0.jre
-		popd >>/dev/null
-	else
-		echo "Warning, j2re bundle not found, DMG packages won't be available"
-	fi
-	
-    echo "produced tarball files under $OBF_DROP_DIR/$OBF_PROJECT_NAME"
-    ls -l $OBF_DROP_DIR/$OBF_PROJECT_NAME/*$OBF_BUILD_NUMBER-$OBF_BUILD_DATE*
+  if [ "$XDEBUG" = "true" ]; then
+    FILENAME_PREFIX="-fastdebug"
+  fi
+
+  tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/jdk$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jdk
+  tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/jre$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jre
+  popd >>/dev/null
+
+  if [ -d $IMAGE_BUILD_DIR/j2sdk-bundle ]; then
+    pushd $IMAGE_BUILD_DIR/j2sdk-bundle >>/dev/null
+    tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2sdk-bundle$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jdk1.9.0.jdk
+    popd >>/dev/null
+  else
+    echo "Warning, j2sdk bundle not found, DMG packages won't be available"
+  fi
+
+  if [ -d $IMAGE_BUILD_DIR/j2re-bundle ]; then
+    pushd $IMAGE_BUILD_DIR/j2re-bundle >>/dev/null
+    tar cjf $OBF_DROP_DIR/$OBF_PROJECT_NAME/j2re-bundle$FILENAME_PREFIX-$OBF_BASE_ARCH-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.tar.bz2 jre1.9.0.jre
+    popd >>/dev/null
+  else
+    echo "Warning, j2re bundle not found, DMG packages won't be available"
+  fi
+
+  echo "produced tarball files under $OBF_DROP_DIR/$OBF_PROJECT_NAME"
+  ls -l $OBF_DROP_DIR/$OBF_PROJECT_NAME/*$OBF_BUILD_NUMBER-$OBF_BUILD_DATE*
 }
 
 #
@@ -331,7 +328,7 @@ if [ "$XUSE_NEW_BUILD_SYSTEM" = "true" ]; then
 else
   build_old
 fi
-	  
+
 #
 # Test Build
 #

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -137,6 +137,7 @@ function build_old()
   echo "### using old build system ###"
 
   NUM_CPUS=`sysctl -n hw.ncpu`
+  [ $NUM_CPUS -gt 8 ] && NUM_CPUS=8
 
   export MILESTONE="$OBF_BUILD_NUMBER"
   export BUILD_NUMBER="$OBF_BUILD_DATE"

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -197,9 +197,11 @@ function build_new()
   mkdir -p $OBF_SOURCES_PATH/common/makefiles
   pushd $OBF_SOURCES_PATH/common/makefiles >>/dev/null
 
-  # patch common/autoconf/version-numbers
-  mv ../autoconf/version-numbers ../autoconf/version-numbers.orig
-  cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
+  # patch ../autoconf/version-numbers
+  if [ -f ../autoconf/version-numbers ]; then
+    mv ../autoconf/version-numbers ../autoconf/version-numbers.orig
+    cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
+  fi
 
   export JDK_BUILD_NUMBER=$OBF_BUILD_DATE
   export MILESTONE=$OBF_MILESTONE
@@ -233,8 +235,10 @@ function build_new()
 
   make images
 
-  # restore original common/autoconf/version-numbers
-  mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+  # restore original ../autoconf/version-numbers
+  if [ -f ../autoconf/version-numbers.orig ]; then
+    mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+  fi
 
   popd >>/dev/null
 }

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -238,7 +238,7 @@ function build_new()
         --enable-unlimited-crypto=yes
   fi
 
-  export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/common/makefiles/images
+  export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/build/$OBF_BASE_ARCH/images
 
   if [ "$XCLEAN" = "true" ]; then
      make clean

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -222,7 +222,7 @@ function build_new()
     sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
-        --with-milestone=$OBF_MILESTONE \
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE \
         --enable-debug
 
   else
@@ -230,7 +230,7 @@ function build_new()
     sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
-        --with-milestone=$OBF_MILESTONE
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE
   fi
 
   export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/common/makefiles/images

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -194,14 +194,12 @@ function build_new()
 {
   echo "### using new build system ###"
 
-  # ensure makefiles dir exists
-  mkdir -p $OBF_SOURCES_PATH/common/makefiles
-  pushd $OBF_SOURCES_PATH/common/makefiles >>/dev/null
+  pushd $OBF_SOURCES_PATH >>/dev/null
 
-  # patch ../autoconf/version-numbers
-  if [ -f ../autoconf/version-numbers ]; then
-    mv ../autoconf/version-numbers ../autoconf/version-numbers.orig
-    cat ../autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > ../autoconf/version-numbers
+  # patch common/autoconf/version-numbers
+  if [ -f common/autoconf/version-numbers ]; then
+    mv common/autoconf/version-numbers common/autoconf/version-numbers.orig
+    cat common/autoconf/version-numbers.orig | grep -v "MILESTONE" | grep -v "JDK_BUILD_NUMBER" | grep -v "COMPANY_NAME" > common/autoconf/version-numbers
   fi
 
   export JDK_BUILD_NUMBER=$OBF_BUILD_DATE
@@ -220,7 +218,7 @@ function build_new()
 
   if [ "$XDEBUG" = "true" ]; then
 
-    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE \
@@ -228,7 +226,7 @@ function build_new()
 
   else
 
-    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE
@@ -242,9 +240,9 @@ function build_new()
 
   make images
 
-  # restore original ../autoconf/version-numbers
-  if [ -f ../autoconf/version-numbers.orig ]; then
-    mv ../autoconf/version-numbers.orig ../autoconf/version-numbers
+  # restore original common/autoconf/version-numbers
+  if [ -f common/autoconf/version-numbers.orig ]; then
+    mv common/autoconf/version-numbers.orig common/autoconf/version-numbers
   fi
 
   popd >>/dev/null

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -238,7 +238,7 @@ function build_new()
      make clean
   fi
 
-  make images
+  make DEBUG_BINARIES=${XDEBUG_BINARIES:-false} images
 
   # restore original common/autoconf/version-numbers
   if [ -f common/autoconf/version-numbers.orig ]; then

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -221,7 +221,7 @@ function build_new()
     sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
-        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE \
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
         --enable-debug
 
   else
@@ -229,7 +229,7 @@ function build_new()
     sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
-        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_MILESTONE
+        --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER
   fi
 
   export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/common/makefiles/images

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -218,7 +218,9 @@ function build_new()
 
   if [ "$XDEBUG" = "true" ]; then
 
-    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR \
+        --with-xcode-path=$OBF_XCODE_PATH \
+        --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER \
@@ -226,7 +228,9 @@ function build_new()
 
   else
 
-    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+    sh $OBF_SOURCES_PATH/common/autoconf/configure --with-boot-jdk=$OBF_BOOTDIR \
+        --with-xcode-path=$OBF_XCODE_PATH \
+        --with-cacerts-file=$OBF_DROP_DIR/cacerts \
         --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
         --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
         --with-build-number=$OBF_BUILD_DATE --with-milestone=$OBF_BUILD_NUMBER

--- a/openjdk9/macosx/build.sh
+++ b/openjdk9/macosx/build.sh
@@ -219,12 +219,18 @@ function build_new()
 
   if [ "$XDEBUG" = "true" ]; then
 
-    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache --enable-debug --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include
+    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
+        --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
+        --with-milestone=$OBF_MILESTONE \
+        --enable-debug
 
   else
 
-    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
-       --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include
+    sh ../autoconf/configure --with-boot-jdk=$OBF_BOOTDIR --with-cacerts-file=$OBF_DROP_DIR/cacerts \
+        --with-ccache-dir=$OBF_WORKSPACE_PATH/.ccache \
+        --with-freetype-lib=$OBF_DROP_DIR/freetype/lib --with-freetype-include=$OBF_DROP_DIR/freetype/include \
+        --with-milestone=$OBF_MILESTONE
   fi
 
   export IMAGE_BUILD_DIR=$OBF_SOURCES_PATH/common/makefiles/images

--- a/openjdk9/macosx/jenkins-job.sh
+++ b/openjdk9/macosx/jenkins-job.sh
@@ -47,8 +47,12 @@ pushd $OBF_SOURCES_PATH >>/dev/null
 #
 # Build System concats OBF_MILESTONE, - and OBF_BUILD_DATE, ie b56-20120908
 #
-export OBF_MILESTONE=`hg tags | grep $TAG_FILTER | head -1 | cut -d ' ' -f 1 | sed 's/^-//'`
-export OBF_BUILD_NUMBER=`hg tags | grep $TAG_FILTER | head -1 | sed "s/$TAG_FILTER//" | cut -d ' ' -f 1 | sed 's/^-//'`
+export OBF_MILESTONE=`hg identify | cut -d ' ' -f 2 | cut -d '/' -f 1`
+if [ "$OBF_MILESTONE" = "tip" ]; then
+  export OBF_MILESTONE=`hg tags | grep $TAG_FILTER | head -1 | cut -d ' ' -f 1`
+fi
+
+export OBF_BUILD_NUMBER=`echo $OBF_MILESTONE | sed "s/$TAG_FILTER//" | sed 's/^-//'`
 export OBF_BUILD_DATE=`date +%Y%m%d`
 
 if [ -z "$OBF_DISTRIBUTION" ]; then

--- a/openjdk9/macosx/jenkins-job.sh
+++ b/openjdk9/macosx/jenkins-job.sh
@@ -38,6 +38,10 @@ if [ -z "$OBF_WORKSPACE_PATH" ]; then
   export OBF_WORKSPACE_PATH=`pwd`
 fi
 
+if [ -z "$OBF_XCODE_PATH" ]; then
+  export OBF_XCODE_PATH=/Application/Xcode.app
+fi
+
 pushd $OBF_SOURCES_PATH >>/dev/null
 
 #

--- a/openjdk9/macosx/jenkins-job.sh
+++ b/openjdk9/macosx/jenkins-job.sh
@@ -17,6 +17,10 @@ if [ -z $OBF_DROP_DIR ]; then
   export OBF_DROP_DIR="$HOME/OBF_DROP_DIR"
 fi
 
+if [ "$XCLEAN" = "true" ]; then
+  rm -rf $OBF_DROP_DIR
+fi
+
 mkdir -p $OBF_DROP_DIR
 
 #

--- a/openjdk9/macosx/package.sh
+++ b/openjdk9/macosx/package.sh
@@ -28,7 +28,7 @@ JRE_BUNDLE=$OBF_DROP_DIR/$OBF_PROJECT_NAME/j2re-bundle$FILENAME_PREFIX-$OBF_BASE
 # 1.9.0 to be injected in Info.plist
 JVM_VERSION=1.9.0
 
-# jdk dirname in template.dmg 
+# jdk dirname in template.dmg
 DMG_BUNDLE_DIR=1.9.0.jdk
 
 #
@@ -40,54 +40,54 @@ DMG_BUNDLE_DIR=1.9.0.jdk
 #
 function build_dmg()
 {
-    PACKAGE_NAME=$1
-    BUNDLE_FILE=$2
-    SRC_BUNDLE=$3
-    DST_BUNDLE=$4
-    FILE_NAME=$5
-  
-    pushd $OBF_BUILD_PATH/dmg >>/dev/null
+  PACKAGE_NAME=$1
+  BUNDLE_FILE=$2
+  SRC_BUNDLE=$3
+  DST_BUNDLE=$4
+  FILE_NAME=$5
 
+  pushd $OBF_BUILD_PATH/dmg >>/dev/null
+
+  rm -rf TEMP
+  mkdir -p TEMP
+
+  if [ -f $BUNDLE_FILE ]; then
+    echo "packaging $PACKAGE_NAME"
+
+    pushd TEMP >>/dev/null
+
+    tar xjf $BUNDLE_FILE
+
+    # Set Milestone and buildnumber in Info.plist
+    sed -i "" -e "s|<string>$JVM_VERSION</string>|<string>$JVM_VERSION-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE</string>|" $SRC_BUNDLE/Contents/Info.plist
+
+    cp ../template.dmg.bz2 .
+    bzip2 -d template.dmg.bz2
+
+    DMG_MOUNT_DIR=`pwd`/MOUNT_DIR
+    mkdir -p $DMG_MOUNT_DIR
+
+    hdiutil attach template.dmg -readwrite -noverify -noautoopen -noautoopenro -noautoopenrw -noautofsck -noidme -noidmereveal -noidmetrash -mountpoint $DMG_MOUNT_DIR
+
+    rm -f $DMG_MOUNT_DIR/$DMG_BUNDLE_DIR
+    mv $SRC_BUNDLE $DMG_MOUNT_DIR/$DST_BUNDLE
+    cp -f ../README $DMG_MOUNT_DIR/README
+    cp -f ../LEGAL $DMG_MOUNT_DIR/LEGAL
+
+    ../SetFileIcon -image ../logo.png -file $DMG_MOUNT_DIR/$DST_BUNDLE
+
+    hdiutil detach $DMG_MOUNT_DIR -quiet -force
+    hdiutil convert template.dmg -format UDZO -imagekey zlib-level=9 -o $FILE_NAME-$OBF_BASE_ARCH-$PACKAGE_NAME-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.dmg
+    rm template.dmg
+
+    mkdir -p $OBF_DROP_DIR/$OBF_PROJECT_NAME
+    mv $FILE_NAME-$OBF_BASE_ARCH-$PACKAGE_NAME-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.dmg $OBF_DROP_DIR/$OBF_PROJECT_NAME
+
+    popd >>/dev/null
     rm -rf TEMP
-    mkdir -p TEMP
-
-    if [ -f $BUNDLE_FILE ]; then
-      echo "packaging $PACKAGE_NAME"
-
-      pushd TEMP >>/dev/null
-
-      tar xjf $BUNDLE_FILE
-    
-      # Set Milestone and buildnumber in Info.plist
-      sed -i "" -e "s|<string>$JVM_VERSION</string>|<string>$JVM_VERSION-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE</string>|" $SRC_BUNDLE/Contents/Info.plist
-  
-      cp ../template.dmg.bz2 .
-      bzip2 -d template.dmg.bz2
-
-      DMG_MOUNT_DIR=`pwd`/MOUNT_DIR
-      mkdir -p $DMG_MOUNT_DIR
-
-      hdiutil attach template.dmg -readwrite -noverify -noautoopen -noautoopenro -noautoopenrw -noautofsck -noidme -noidmereveal -noidmetrash -mountpoint $DMG_MOUNT_DIR
-
-      rm -f $DMG_MOUNT_DIR/$DMG_BUNDLE_DIR
-      mv $SRC_BUNDLE $DMG_MOUNT_DIR/$DST_BUNDLE
-      cp -f ../README $DMG_MOUNT_DIR/README
-      cp -f ../LEGAL $DMG_MOUNT_DIR/LEGAL
-
-      ../SetFileIcon -image ../logo.png -file $DMG_MOUNT_DIR/$DST_BUNDLE
-
-      hdiutil detach $DMG_MOUNT_DIR -quiet -force
-      hdiutil convert template.dmg -format UDZO -imagekey zlib-level=9 -o $FILE_NAME-$OBF_BASE_ARCH-$PACKAGE_NAME-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.dmg
-      rm template.dmg
-  
-      mkdir -p $OBF_DROP_DIR/$OBF_PROJECT_NAME
-      mv $FILE_NAME-$OBF_BASE_ARCH-$PACKAGE_NAME-$OBF_BUILD_NUMBER-$OBF_BUILD_DATE.dmg $OBF_DROP_DIR/$OBF_PROJECT_NAME
-  
-      popd >>/dev/null
-      rm -rf TEMP
-    else
-      echo "missing $PACKAGE_NAME bundle tarball $BUNDLE_FILE, skipping packaging"
-    fi
+  else
+    echo "missing $PACKAGE_NAME bundle tarball $BUNDLE_FILE, skipping packaging"
+  fi
 }
 
 # jdk/jre

--- a/openjdk9/macosx/standalone-job.sh
+++ b/openjdk9/macosx/standalone-job.sh
@@ -25,14 +25,14 @@ fi
 if [ ! -d $OBF_SOURCES_PATH ]; then
   hg clone http://hg.openjdk.java.net/jdk9/jdk9 $OBF_SOURCES_PATH
 else
-  pushd $OBF_SOURCES_PATH >>/dev/null	
+  pushd $OBF_SOURCES_PATH >>/dev/null
   hg update
   popd >>/dev/null
-fi	
-	
+fi
+
 pushd $OBF_SOURCES_PATH >>/dev/null
 
-# 
+#
 # Updating sources for Mercurial repo
 #
 sh ./get_source.sh

--- a/openjdk9/macosx/standalone-job.sh
+++ b/openjdk9/macosx/standalone-job.sh
@@ -46,7 +46,7 @@ fi
 #
 if [ ! -z "$XUSE_TAG" ]; then
   echo "using tag $XUSE_TAG"
-  sh ./make/scripts/hgforest.sh update $XUSE_TAG
+  sh ./make/scripts/hgforest.sh update --clean $XUSE_TAG
 fi
 
 popd >>/dev/null

--- a/openjdk9/macosx/standalone-job.sh
+++ b/openjdk9/macosx/standalone-job.sh
@@ -37,6 +37,10 @@ pushd $OBF_SOURCES_PATH >>/dev/null
 #
 sh ./get_source.sh
 
+if [ -n "$XUSE_UPDATE" ]; then
+  XUSE_TAG=`hg tags | grep "jdk9u$XUSE_UPDATE" | head -1 | cut -d ' ' -f 1`
+fi
+
 #
 # Update sources to provided tag XUSE_TAG (if defined)
 #

--- a/openjdk9/macosx/test.sh
+++ b/openjdk9/macosx/test.sh
@@ -13,7 +13,7 @@
 function ensure_jtreg()
 {
   if [ ! -f $OBF_DROP_DIR/jtreg/win32/bin/jtreg ]; then
-  
+
     JTREG_VERSION=b05
 
     if [ ! -f $OBF_DROP_DIR/jtreg-$JTREG_VERSION.zip ]; then


### PR DESCRIPTION
I’ve tested scripts for OpenJDK 8 on OS X 10.9.5 with Xcode 4.6.5 and it now works well. I haven’t tested OpenJDK 9 yet.