### PR TITLE
fix freetype 2.4.10 install error and cert confirmation locale

### DIFF
--- a/openjdk7/macosx/build.sh
+++ b/openjdk7/macosx/build.sh
@@ -66,7 +66,7 @@ function cacerts_gen()
 
   for CERT_FILE in cert_*; do
     ALIAS=$(basename ${CERT_FILE})
-    echo yes | keytool -import -alias ${ALIAS} -keystore cacerts -storepass 'changeit' -file ${CERT_FILE} || :
+    keytool -noprompt -import -alias ${ALIAS} -keystore cacerts -storepass 'changeit' -file ${CERT_FILE} || :
     rm -f $CERT_FILE
   done
 
@@ -114,6 +114,11 @@ function ensure_freetype()
 	    curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-modules.cfg.diff -o $OBF_DROP_DIR/freetype-patches/patch-modules.cfg.diff
 	    curl -L https://trac.macports.org/export/92468/trunk/dports/print/freetype/files/patch-src_base_ftrfork.c.diff -o $OBF_DROP_DIR/freetype-patches/patch-src_base_ftrfork.c.diff
 	  fi
+
+    # only patch with free type 2.4.10 install.mk
+    if [ "$FREETYPE_VERSION" = "2.4.10" ]; then
+      cp $OBF_BUILD_PATH/patches/patch_unix_install_mk_2.4.10.diff $OBF_DROP_DIR/freetype-patches/
+    fi
 
 	  rm -rf freetype-$FREETYPE_VERSION
 	  rm -rf $OBF_DROP_DIR/freetype

--- a/openjdk7/macosx/patches/patch_unix_install_mk_2.4.10.diff
+++ b/openjdk7/macosx/patches/patch_unix_install_mk_2.4.10.diff
@@ -1,0 +1,10 @@
+--- builds/unix/install.mk.orig	2017-01-03 10:19:23.000000000 +0800
++++ builds/unix/install.mk	2017-01-03 10:19:36.000000000 +0800
+@@ -32,6 +32,7 @@
+                          $(DESTDIR)$(libdir)/pkgconfig                     \
+                          $(DESTDIR)$(includedir)/freetype2/freetype/config \
+                          $(DESTDIR)$(includedir)/freetype2/freetype/cache  \
++                         $(DESTDIR)$(includedir)/freetype2/freetype/internal  \
+                          $(DESTDIR)$(bindir)                               \
+                          $(DESTDIR)$(datadir)/aclocal
+ 	$(LIBTOOL) --mode=install $(INSTALL)                             \


### PR DESCRIPTION
Fix 2 issues:
1. when import cert with keytool, we should add "-noprompt" without confirmation, so it will be successful in any locale and languange, the current "echo yes" will be failed with chinese language, because in chinese, it should be "echo 是"

2. create "internal" dir in freetype to slove the issues
https://github.com/hgomez/obuildfactory/issues/39
https://github.com/hgomez/obuildfactory/issues/48