### PR TITLE
Update docker build of openjdk 8 and 9 for centos and ubuntu

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,12 +7,13 @@ clean:
 
 
 obuildfactory-%: %
-	cat $< | sudo docker build -t obuildfactory-$< -
+	cat $< | sudo docker build -t obuildfactory-$< --build-arg BUILD_UID=`id -u` -
 
 %-openjdk8: obuildfactory-%
 	mkdir -p build/$@/sources
 	mkdir -p build/$@/binaries
 	sudo docker run \
+		-u `id -u` \
 		-v `pwd`/build/$@/binaries:/openjdk/OBF_DROP_DIR \
 		-v `pwd`/build/$@/sources:/openjdk/sources \
 		 $< ./obuildfactory/openjdk8/linux/standalone-job.sh 
@@ -22,6 +23,7 @@ obuildfactory-%: %
 	mkdir -p build/$@/binaries
 	tar -C build/$@ -xjf build/$(shell echo $@ | sed 's/jdk9/jdk8/')/binaries/openjdk8/j2sdk-image-*.tar.bz2
 	sudo docker run \
+		-u `id -u` \
 		-v `pwd`/build/$@/j2sdk-image:/openjdk/j2sdk-image \
 		-v `pwd`/build/$@/binaries:/openjdk/OBF_DROP_DIR \
 		-v `pwd`/build/$@/sources:/openjdk/sources \

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,14 +14,19 @@ only a limited number of rules for a limited number of
 distributions. However, in theory, one jenkins host with docker could
 probably the majority if not all packages for all linux distributions.
 
+
+```
 $ make centos7-openjdk8
+```
 
   or
 
-$ make ubuntu14-openjdk8
+```
+$ make ubuntu15-openjdk8
+```
 
 These would would leave RPMs or DEBs under
-build/centos7-openjdk8/binaries or build/ubuntu14-openjdk8/binaries
+build/centos7-openjdk8/binaries or build/ubuntu15-openjdk8/binaries
 respectively.
 
 ## Bootstrapping OpenJDK9
@@ -29,9 +34,13 @@ respectively.
 The rules for OpenJDK9 require that you build OpenJDK8 first. So, for
 example:
 
+```
 $ make centos7-openjdk8
-$ make centos7-openjdk8
+$ make centos7-openjdk9
+```
 
   or
 
+```
 $ make centos7-openjdk8 centos7-openjdk9
+```

--- a/docker/centos7
+++ b/docker/centos7
@@ -6,12 +6,23 @@ RUN yum install -y ccache make gcc gcc-c++ libstdc++-devel
 RUN yum install -y alsa-lib-devel cups-devel libX11-devel libXext-devel libXt-devel libXrender-devel libXtst-devel libXi-devel libjpeg-devel giflib-devel freetype-devel
 RUN yum install -y curl rpm-build gpg
 RUN yum install -y java-1.7.0-openjdk-devel
-RUN yum install -y ruby-devel
+RUN yum install -y epel-release
+RUN yum install -y ruby-devel which autoconf ccache
 RUN gem install fpm
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.7.0
+ENV OBF_JAVA7_HOME /usr/lib/jvm/java-1.7.0
+
+ARG BUILD_USER=obuild
+ARG BUILD_UID=2000
+
+RUN useradd -u $BUILD_UID $BUILD_USER
 
 WORKDIR /openjdk
+
+RUN chown -R $BUILD_USER .
+
+USER $BUILD_USER
 
 RUN git clone https://github.com/hgomez/obuildfactory.git
 

--- a/docker/ubuntu14
+++ b/docker/ubuntu14
@@ -1,5 +1,5 @@
 
-FROM ubuntu:utopic
+FROM ubuntu:trusty
 
 RUN apt-get update
 RUN apt-get install -y git mercurial zip bzip2 unzip tar curl
@@ -11,8 +11,18 @@ RUN apt-get install -y openjdk-7-jdk
 RUN gem install fpm
 
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+ENV OBF_JAVA7_HOME /usr/lib/jvm/java-7-openjdk-amd64
+
+ARG BUILD_USER=obuild
+ARG BUILD_UID=2000
+
+RUN useradd -u $BUILD_UID $BUILD_USER
 
 WORKDIR /openjdk
+
+RUN chown -R $BUILD_USER .
+
+USER $BUILD_USER
 
 RUN git clone https://github.com/hgomez/obuildfactory.git
 

--- a/docker/ubuntu15
+++ b/docker/ubuntu15
@@ -11,8 +11,18 @@ RUN apt-get install -y openjdk-7-jdk
 RUN gem install fpm
 
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+ENV OBF_JAVA7_HOME /usr/lib/jvm/java-7-openjdk-amd64
+
+ARG BUILD_USER=obuild
+ARG BUILD_UID=2000
+
+RUN useradd -u $BUILD_UID $BUILD_USER
 
 WORKDIR /openjdk
+
+RUN chown -R $BUILD_USER .
+
+USER $BUILD_USER
 
 RUN git clone https://github.com/hgomez/obuildfactory.git
 


### PR DESCRIPTION
In case this is useful for others as well I've updated these rules to adjust to changes to docker and the obuildfactory scripts. It helps me with building the current openjdk source as packages and testing out changes to openjdk.